### PR TITLE
Update magstim.m

### DIFF
--- a/magstim.m
+++ b/magstim.m
@@ -20,18 +20,11 @@ classdef magstim < handle
     methods 
         function self = magstim(PortID)
             % PortID <char> defines the serail port id on your computer
-           
-            %% Find All Available Serial Ports On Your Computer
-            foundPorts = instrhwinfo('serial');
-            listOfComPorts = foundPorts.AvailableSerialPorts;
-            
+                     
             %% Check Input Validity:
             narginchk(1, 1);
-            if ~ischar(PortID) || (~isstring(PortID) && (numel(PortID) == 1))
+            if ~ischar(PortID) || (exist('string','class') && (~isstring(PortID) && (numel(PortID) == 1))
                 error('The serial port ID must be a character or string array.');
-            end
-            if ~any(strcmp(listOfComPorts, PortID))
-                error('Serial com port ID not found.');
             end
             
             self.portID = PortID;


### PR DESCRIPTION
This change removes checking whether the supplied port name exists (and is open) - instead it should return an error when trying to open it. This is to avoid using the instrhwinfo (requires Instrument Control Toolbox) and seriallist (MATLAB v2017a+ only) functions.

It also adds a check for whether strings exist (MATLAB 2016a+ only) before checking whether the supplied port name is a valid string